### PR TITLE
Consolidate duplicated markdown parsing into shared utility

### DIFF
--- a/src/lib/experiencePageData.ts
+++ b/src/lib/experiencePageData.ts
@@ -1,4 +1,4 @@
-import { marked } from "marked";
+import { parseMarkdown } from "./markdown";
 import {
   getExperienceForPage,
   listExperienceDetailPageKeys,
@@ -6,8 +6,6 @@ import {
   isProjectDetailPageKey,
   type ExperienceRecord,
 } from "./experiences";
-
-marked.use({ gfm: true });
 
 /** Canonical URL for a published experience write-up (project markdown → `/projects/…`). */
 export function experienceDetailPath(key: string): string {
@@ -37,8 +35,6 @@ export async function experiencePageProps(key: string): Promise<{
 }> {
   const exp = getExperienceForPage(key);
   if (!exp) throw new Error(`Unknown or unpublished experience: ${key}`);
-  const parsed = marked.parse(exp.description);
-  const contentHtml =
-    typeof parsed === "string" ? parsed : await Promise.resolve(parsed);
+  const contentHtml = await parseMarkdown(exp.description);
   return { exp, contentHtml };
 }

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,9 @@
+import { marked } from "marked";
+
+marked.use({ gfm: true });
+
+/** Parse a Markdown string to HTML using GFM. */
+export async function parseMarkdown(markdown: string): Promise<string> {
+  const parsed = marked.parse(markdown);
+  return typeof parsed === "string" ? parsed : await parsed;
+}

--- a/src/pages/coding-expedition.html.astro
+++ b/src/pages/coding-expedition.html.astro
@@ -5,14 +5,11 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 import SiteNav from "../components/SiteNav.astro";
 import { site } from "../data/site";
-import { marked } from "marked";
-
-marked.use({ gfm: true });
+import { parseMarkdown } from "../lib/markdown";
 
 const mdPath = path.join(process.cwd(), "data", "coding_expedition.md");
 const md = fs.readFileSync(mdPath, "utf8");
-const parsed = marked.parse(md);
-const proseHtml = typeof parsed === "string" ? parsed : await parsed;
+const proseHtml = await parseMarkdown(md);
 
 const mapsKey = import.meta.env.PUBLIC_GOOGLE_MAPS_API_KEY ?? "";
 const mapsScriptSrc = mapsKey

--- a/src/pages/experience.html.astro
+++ b/src/pages/experience.html.astro
@@ -2,14 +2,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import MarkdownArticle from "../components/MarkdownArticle.astro";
-import { marked } from "marked";
-
-marked.use({ gfm: true });
+import { parseMarkdown } from "../lib/markdown";
 
 const mdPath = path.join(process.cwd(), "data", "experience_summary.md");
 const md = fs.readFileSync(mdPath, "utf8");
-const parsed = marked.parse(md);
-const contentHtml = typeof parsed === "string" ? parsed : await parsed;
+const contentHtml = await parseMarkdown(md);
 ---
 
 <MarkdownArticle


### PR DESCRIPTION
## Summary
- Extracted a shared `parseMarkdown()` function into `src/lib/markdown.ts` that initializes `marked` with GFM once and handles the string-or-promise return type
- Updated `experience.html.astro`, `coding-expedition.html.astro`, and `experiencePageData.ts` to use the new utility, removing duplicated `marked.use({ gfm: true })` and parse-then-await boilerplate from each file
- Net result: 4 files changed, 15 insertions, 16 deletions

## Test plan
- [x] All 83 existing tests pass (`vitest run`)
- [ ] Verify experience page renders correctly
- [ ] Verify coding expedition page renders correctly
- [ ] Verify individual experience detail pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)